### PR TITLE
fix LiveProf-UI aggregator saveMethodData behavior 

### DIFF
--- a/src/Badoo/LiveProfilerUI/Aggregator.php
+++ b/src/Badoo/LiveProfilerUI/Aggregator.php
@@ -426,7 +426,7 @@ class Aggregator
         foreach ($this->method_data as $method_name => $data) {
             $insert_data = [
                 'snapshot_id' => $snapshot_id,
-                'method_id' => (int)$map[strtolower($method_name)]['id'],
+                'method_id' => $map[trim(strtolower($method_name))]['id'],
             ];
             foreach ($this->fields as $field) {
                 $insert_data[$field] = (float)$data[$field];


### PR DESCRIPTION
for xhprof_sampling_data results with ```mysql_query#extra_long_string_with_spaces```
saveMethodData cant resolve function name from $map when this exists

should i provide additional test for coverage this corner case?
