### PR TITLE
FIx common issue with Aggregator::splitMethods

### DIFF
--- a/src/Badoo/LiveProfilerUI/Aggregator.php
+++ b/src/Badoo/LiveProfilerUI/Aggregator.php
@@ -588,7 +588,7 @@ class Aggregator
      */
     protected function splitMethods(string $key) : array
     {
-        if (false === strpos('==>', $key)) {
+        if (false === strpos($key, '==>')) {
             return [0, $key];
         } 
           

--- a/src/Badoo/LiveProfilerUI/Aggregator.php
+++ b/src/Badoo/LiveProfilerUI/Aggregator.php
@@ -589,12 +589,9 @@ class Aggregator
     protected function splitMethods(string $key) : array
     {
         if (false === strpos('==>', $key)) {
-            $caller = 0;
-            $callee = $key;
-        } else {
-            list($caller, $callee) = explode('==>', $key);
-        }
-
-        return [$caller, $callee];
+            return [0, $key];
+        } 
+          
+        return explode('==>', $key);
     }
 }

--- a/src/Badoo/LiveProfilerUI/Aggregator.php
+++ b/src/Badoo/LiveProfilerUI/Aggregator.php
@@ -232,7 +232,11 @@ class Aggregator
             foreach ($this->fields as $profile_param => $aggregator_param) {
                 $value = $stats[$profile_param] > 0 ? $stats[$profile_param] : 0;
                 $this->call_map[$caller][$callee][$aggregator_param . 's'] .= $value . ',';
-                $this->method_data[$callee][$aggregator_param . 's'] .= $value . ',';
+                if (array_key_exists($aggregator_param . 's', $this->method_data[$callee])) {
+                    $this->method_data[$callee][$aggregator_param . 's'] .= $value . ',';
+                } else {
+                    $this->method_data[$callee][$aggregator_param . 's'] = $value . ',';
+                }
             }
         }
         unset($this->call_map[0], $this->methods[0]);

--- a/src/Badoo/LiveProfilerUI/Aggregator.php
+++ b/src/Badoo/LiveProfilerUI/Aggregator.php
@@ -588,9 +588,9 @@ class Aggregator
      */
     protected function splitMethods(string $key) : array
     {
-        if ($key === 'main()') {
+        if (false === strpos('==>', $key)) {
             $caller = 0;
-            $callee = 'main()';
+            $callee = $key;
         } else {
             list($caller, $callee) = explode('==>', $key);
         }


### PR DESCRIPTION
We've got many warnings where Aggregator tries to split methods like `defined`, `microtime`, `spl_autoload_register`.