### PR TITLE
xhprof sampling mode doesnt return cpu etc

### DIFF
--- a/src/Badoo/LiveProfilerUI/Aggregator.php
+++ b/src/Badoo/LiveProfilerUI/Aggregator.php
@@ -230,7 +230,7 @@ class Aggregator
             }
 
             foreach ($this->fields as $profile_param => $aggregator_param) {
-                $value = $stats[$profile_param] > 0 ? $stats[$profile_param] : 0;
+                $value = array_key_exists($profile_param, $stats) && $stats[$profile_param] > 0 ? $stats[$profile_param] : 0;
                 $this->call_map[$caller][$callee][$aggregator_param . 's'] .= $value . ',';
                 if (array_key_exists($aggregator_param . 's', $this->method_data[$callee])) {
                     $this->method_data[$callee][$aggregator_param . 's'] .= $value . ',';


### PR DESCRIPTION
Добрый день! 

Попробовал подключить профайлер к своему проекту через xhprof. Использовал **useXhprofSample**. Поймал ворнинг:

    PHP Warning:  Undefined array key "cpu" in /home/doctor-external/work/queue-liveprof-ui/src/Badoo/LiveProfilerUI/Aggregator.php on line 233

Если использовать сэмплирующий режим xhprof, то он не заносит в базу метрики по процессорному времени и памяти. Добавил проверку на наличие ключа